### PR TITLE
new vagrant file with yaml

### DIFF
--- a/ansible/setup.yml
+++ b/ansible/setup.yml
@@ -1,0 +1,156 @@
+---
+- hosts: vagrant
+  remote_user: vagrant
+  sudo: yes
+  vars:
+    mysqlUser: root
+    mysqlPass: vagrant
+    dbUser: vagrant
+    dbPass: vagrant
+    dbName: wordpress
+    wordpressPath: /home/vagrant/www
+    vhostTemplatePath: templates/vhost.conf
+    mysqlTemplatePath: templates/mysql
+  tasks:
+    - name: Install unzip
+      apt: pkg=unzip state=latest update_cache=yes
+
+
+    - name: Install MySQL client, server and related libraries
+      apt: pkg={{ item }} state=latest
+      with_items:
+        - mysql-client
+        - mysql-server
+        - python-mysqldb
+
+
+    - name: Install PHP and its modules
+      apt: pkg={{ item }} state=latest
+      with_items:
+        - php5
+        - php5-cli
+        - php5-curl
+        - php5-gd
+        - php5-imagick
+        - php5-mysql
+        - php5-xmlrpc
+
+
+    - name: Install Apache and its modules
+      apt: pkg={{ item }} state=latest
+      with_items:
+        - apache2
+        - libapache2-mod-php5
+
+
+    - name: Activate mod_rewrite
+      apache2_module: name=rewrite state=present
+
+
+    - name: Start MySQL service
+      service:
+        name: "mysql"
+        state: started
+        enabled: yes
+
+
+    - name: Setup MySQL root password
+      mysql_user:
+        name: "root"
+        password: "{{ mysqlPass }}"
+        host: "{{ item }}"
+        state: present
+      with_items:
+        - "{{ ansible_hostname }}"
+        - 127.0.0.1
+        - ::1
+        - localhost
+
+
+    - name: Setup MySQL creds for root user
+      template:
+        src: "{{ mysqlTemplatePath }}"
+        dest: "/root/.my.cnf"
+        owner: "root"
+        mode: 0600
+
+
+    - name: Delete blank MySQL users
+      mysql_user:
+        name: ""
+        host: "{{ item }}"
+        state: absent
+      with_items:
+        - "{{ ansible_hostname }}"
+        - 127.0.0.1
+        - ::1
+        - localhost
+
+
+    - name: Drop MySQL test database
+      mysql_db: name=test state=absent
+
+
+    - name: Setup empty database for WordPress
+      mysql_db:
+        name: "{{ dbName }}"
+        encoding: "utf8"
+        collation: "utf8_unicode_ci"
+        state: "present"
+        login_user: "root"
+        login_password: "{{ mysqlPass }}"
+
+
+    - name: Setup MySQL user for WordPress
+      mysql_user:
+        name: "{{ dbUser }}"
+        password: "{{ dbPass }}"
+        host: "localhost"
+        priv: "wordpress.*:ALL"
+        state: "present"
+
+
+    - name: Put "vagrant" user in www-data group
+      user:
+        name: "vagrant"
+        groups: "www-data"
+        append: yes
+
+
+    - name: Unzip WordPress
+      unarchive:
+        src: ../wordpress.zip
+        dest: "{{ wordpressPath }}"
+
+
+    - name: Symlink web root to unzipped WordPress
+      file:
+        src: "{{ wordpressPath }}/wordpress"
+        dest: "/var/www/wordpress"
+        state: "link"
+
+
+    - name: Copy virtual host setup over
+      template:
+        src: "{{ vhostTemplatePath }}"
+        dest: /etc/apache2/sites-available/
+
+
+    - name: Activate virtual host
+      command: a2ensite vhost
+
+
+    - name: Deactivate default vhost
+      command: a2dissite 000-default
+
+
+    - name: Ensure Apache is running
+      service: name=apache2 state=restarted enabled=yes
+
+
+    - name: Install git
+      action: apt pkg=git state=installed
+
+
+    - name: Install git-core
+      action: apt pkg=git-core state=installed

--- a/ansible/templates/mysql
+++ b/ansible/templates/mysql
@@ -1,0 +1,3 @@
+[client]
+user=root
+password=vagrant

--- a/ansible/templates/vhost.conf
+++ b/ansible/templates/vhost.conf
@@ -1,0 +1,15 @@
+<VirtualHost *:80>
+    ServerAdmin webmaster@localhost
+    
+    DocumentRoot /var/www/wordpress
+    <Directory /var/www/wordpress/>
+        Options -Indexes +Includes +FollowSymLinks +Multiviews
+        AllowOverride All
+        Order allow,deny
+        allow from all
+    </Directory>
+    
+    ErrorLog /var/log/apache2/error.log
+    CustomLog /var/log/apache2/access.log combined
+    
+</VirtualHost>


### PR DESCRIPTION
Hi, great work, thanks for sharing
i was using puppet for my wordpress development but now I'm using ansible and i discover your work. 
i made some changes for more control in the configuration, if you like my changes you can merge or use  parts.
Thanks.

Changes:
     - Integration with yaml 
     - Vagrantfile          
            - The vagrant file is configurable by changing values in 
            ```config.yaml``` all configurations are there

    - Inventory File
        The inventory file is generated by ```Vagrantfile``` because this way you don't
        need to change the IP in different files, just setting the ip in the 
        ```config.yaml``` file will do the work and creates the inventory file.

    -Ansible        
        - Ansible provider move to a sub folder called ```ansible```
        - Add vars for ansible, they are in ```setup.yml" in ```var:``` section
        - If you change in ```setup.yml`` the value of ```mysqlPass: vagrant``` you 
      most change in  ```ansible/templates/mysql```
        - Install git

    - Mysql
        - change root passwords; now is ```vagrant```
        - The database for wordpress  user and pass is ```vagrant```

    - WordPress.
        - change location:
            host: www/wordpress
            guest: /home/vagrant/www/wordpress